### PR TITLE
fix: Set type from API response in Variable instance

### DIFF
--- a/lib/Api/DevCycleClient.php
+++ b/lib/Api/DevCycleClient.php
@@ -585,9 +585,9 @@ class DevCycleClient
         }
 
         if (!$doTypesMatch) {
-            return new Variable(array("key" => $key, "value" => $default, "isDefaulted" => true));
+            return new Variable(array("key" => $key, "value" => $default, "type" => $response['type'], "isDefaulted" => true));
         } else {
-            return new Variable(array("key" => $key, "value" => $unwrappedValue, "isDefaulted" => false));
+            return new Variable(array("key" => $key, "value" => $unwrappedValue, "type" => $response['type'], "isDefaulted" => false));
         }
     }
 


### PR DESCRIPTION
There is a bit of inconsistency in the way of how `\DevCycle\Api\DVCClient::variable` and `\DevCycle\Api\DVCClient::allVariables` work. Both return the same Variable instance (or collection of instances) but in case of `allVariables` we set "type" by deserializing API response into Variable object.
```
$returnType = 'array<string,\DevCycle\Model\Variable>';
if ($returnType === '\SplFileObject') {
      $content = $response->getBody(); //stream goes to serializer
} else {
      $content = (string)$response->getBody();
}

return [
      ObjectSerializer::deserialize($content, $returnType, []),
      $response->getStatusCode(),
      $response->getHeaders()
];
```
In `variable` method we're missing "type"  because it's not set
```
# \DevCycle\Api\DVCClient::reformatVariable

if (!$doTypesMatch) {
      return new Variable(array("key" => $key, "value" => $default, "isDefaulted" => true));
} else {
      return new Variable(array("key" => $key, "value" => $unwrappedValue, "isDefaulted" => false));
}
```
hence we're not able to determine if our variable is exactly the same type as we expected.