### PR TITLE
Allow overriding guzzle http options

### DIFF
--- a/lib/Api/DevCycleClient.php
+++ b/lib/Api/DevCycleClient.php
@@ -814,8 +814,8 @@ class DevCycleClient
         $options["curl"] = $this->dvcOptions->getUnixSocketPath() == "" ? [] : [
             CURLOPT_UNIX_SOCKET_PATH => $this->dvcOptions->getUnixSocketPath()
         ];
-
-        return $options;
+        $options['http_errors'] = false;
+        return array_merge($options, $this->dvcOptions->getHttpOptions());
     }
 
     /**

--- a/lib/Model/DevCycleOptions.php
+++ b/lib/Model/DevCycleOptions.php
@@ -16,6 +16,8 @@ class DevCycleOptions
 
     protected ?string $unixSocketPath = null;
 
+    protected array $httpOptions = [];
+
     /**
      * Constructor
      *
@@ -23,13 +25,14 @@ class DevCycleOptions
      * @param string|null $bucketingApiHostname
      * @param string|null $unixSocketPath
      */
-    public function __construct(bool $enableEdgeDB = false, string $bucketingApiHostname = null, ?string $unixSocketPath = null)
+    public function __construct(bool $enableEdgeDB = false, string $bucketingApiHostname = null, ?string $unixSocketPath = null, array $httpOptions = [])
     {
         $this->enableEdgeDB = $enableEdgeDB;
         if ($bucketingApiHostname !== null) {
             $this->bucketingApiHostname = $bucketingApiHostname;
         }
         $this->unixSocketPath = $unixSocketPath;
+        $this->httpOptions = $httpOptions;
     }
 
     /**
@@ -58,5 +61,10 @@ class DevCycleOptions
     public function getUnixSocketPath(): ?string
     {
         return $this->unixSocketPath;
+    }
+
+    public function getHttpOptions(): array
+    {
+        return $this->httpOptions;
     }
 }

--- a/test/Api/DevCycleClientTest.php
+++ b/test/Api/DevCycleClientTest.php
@@ -120,6 +120,10 @@ final class DevCycleClientTest extends TestCase
         self::assertTrue($boolValue);
         $resultValue = self::$client->variableValue(self::$user, 'php-sdk', false);
         self::assertTrue($resultValue);
+
+        $result = self::$client->variable(self::$user, 'php-sdk-default-invalid', true);
+        self::assertTrue($result->isDefaulted());
+        self::assertTrue((bool)$result->getValue());
     }
 
     /**


### PR DESCRIPTION
Enables the ability to override the guzzle http options.
Sets http_errors to false to silence guzzle errors.
