### PR TITLE
fix: make implicitly nullable parameters explicit

### DIFF
--- a/lib/Api/DevCycleClient.php
+++ b/lib/Api/DevCycleClient.php
@@ -71,9 +71,9 @@ class DevCycleClient
     public function __construct(
         string $sdkKey,
         DevCycleOptions   $dvcOptions,
-        HTTPConfiguration $config = null,
-        ClientInterface   $client = null,
-        HeaderSelector    $selector = null,
+        ?HTTPConfiguration $config = null,
+        ?ClientInterface   $client = null,
+        ?HeaderSelector    $selector = null,
     )
     {
         if ($sdkKey === '') {

--- a/lib/ApiException.php
+++ b/lib/ApiException.php
@@ -40,7 +40,7 @@ class ApiException extends Exception
      * @param string[]|null         $responseHeaders HTTP response header
      * @param string|stdClass|null $responseBody    HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct(string $message = "", int $code = 0, $responseHeaders = [], string|stdClass $responseBody = null)
+    public function __construct(string $message = "", int $code = 0, $responseHeaders = [], string|stdClass|null $responseBody = null)
     {
         parent::__construct($message, $code);
         $this->responseHeaders = $responseHeaders;

--- a/lib/Model/DevCycleEvent.php
+++ b/lib/Model/DevCycleEvent.php
@@ -165,10 +165,10 @@ class DevCycleEvent implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['type'] = $data['type'] ?? null;
         $this->container['target'] = $data['target'] ?? null;

--- a/lib/Model/DevCycleOptions.php
+++ b/lib/Model/DevCycleOptions.php
@@ -25,7 +25,7 @@ class DevCycleOptions
      * @param string|null $bucketingApiHostname
      * @param string|null $unixSocketPath
      */
-    public function __construct(bool $enableEdgeDB = false, string $bucketingApiHostname = null, ?string $unixSocketPath = null, array $httpOptions = [])
+    public function __construct(bool $enableEdgeDB = false, ?string $bucketingApiHostname = null, ?string $unixSocketPath = null, array $httpOptions = [])
     {
         $this->enableEdgeDB = $enableEdgeDB;
         if ($bucketingApiHostname !== null) {

--- a/lib/Model/DevCycleUser.php
+++ b/lib/Model/DevCycleUser.php
@@ -229,10 +229,10 @@ class DevCycleUser implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['user_id'] = $data['user_id'] ?? null;
         $this->container['email'] = $data['email'] ?? null;

--- a/lib/Model/DevCycleUserAndEventsBody.php
+++ b/lib/Model/DevCycleUserAndEventsBody.php
@@ -150,10 +150,10 @@ class DevCycleUserAndEventsBody implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['events'] = $data['events'] ?? null;
         $this->container['user'] = $data['user'] ?? null;

--- a/lib/Model/ErrorResponse.php
+++ b/lib/Model/ErrorResponse.php
@@ -155,10 +155,10 @@ class ErrorResponse implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['message'] = $data['message'] ?? null;
         $this->container['data'] = $data['data'] ?? null;

--- a/lib/Model/Feature.php
+++ b/lib/Model/Feature.php
@@ -194,10 +194,10 @@ class Feature implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param array[] $data Associated array of property values
+     * @param array[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['_id'] = $data['_id'] ?? null;
         $this->container['key'] = $data['key'] ?? null;

--- a/lib/Model/InlineResponse201.php
+++ b/lib/Model/InlineResponse201.php
@@ -147,10 +147,10 @@ class InlineResponse201 implements ModelInterface, ArrayAccess, \JsonSerializabl
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['message'] = $data['message'] ?? null;
     }

--- a/lib/Model/Variable.php
+++ b/lib/Model/Variable.php
@@ -189,10 +189,10 @@ class Variable implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Constructor
      *
-     * @param mixed[] $data Associated array of property values
+     * @param mixed[]|null $data Associated array of property values
      *                      initializing the model
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->container['_id'] = $data['_id'] ?? null;
         $this->container['key'] = $data['key'] ?? null;

--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -186,7 +186,7 @@ class ObjectSerializer
      * @param null $httpHeaders HTTP headers
      * @return object|array|null a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, ?$httpHeaders = null)
+    public static function deserialize(mixed $data, string $class, mixed $httpHeaders = null)
     {
         if (null === $data) {
             return null;

--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -18,7 +18,7 @@ class ObjectSerializer
      * @param string|null $format the format of the OpenAPITools type of the data
      *
      */
-    public static function sanitizeForSerialization(mixed $data, string $type = null, string $format = null): mixed
+    public static function sanitizeForSerialization(mixed $data, ?string $type = null, ?string $format = null): mixed
     {
         if (is_scalar($data) || null === $data) {
             return $data;
@@ -186,7 +186,7 @@ class ObjectSerializer
      * @param null $httpHeaders HTTP headers
      * @return object|array|null a single or an array of $class instances
      */
-    public static function deserialize(mixed $data, string $class, $httpHeaders = null)
+    public static function deserialize(mixed $data, string $class, ?$httpHeaders = null)
     {
         if (null === $data) {
             return null;


### PR DESCRIPTION
With PHP 8.4, implicitly nullable parameter declarations are deprecated ([docs](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated) ). I made all declarations explicit and updated docs where needed.