### PR TITLE
chore(deps): bump open-feature/sdk to 2.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^7.15.1",
         "guzzlehttp/psr7": "^2.12.1",
-        "open-feature/sdk": "^2.0.10"
+        "open-feature/sdk": "^2.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5.62",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ffdf08cd15c2412b8e2c29a855abfd9",
+    "content-hash": "3a0c51ac3c26ba73a0373b7f895a1fa3",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -402,16 +402,16 @@
         },
         {
             "name": "open-feature/sdk",
-            "version": "2.0.10",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/open-feature/php-sdk.git",
-                "reference": "c71bf429267f0a3cfd50348aaf8d091d68b1491b"
+                "reference": "eacce4e1465e098223d46dd71029928d9a52f57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/open-feature/php-sdk/zipball/c71bf429267f0a3cfd50348aaf8d091d68b1491b",
-                "reference": "c71bf429267f0a3cfd50348aaf8d091d68b1491b",
+                "url": "https://api.github.com/repos/open-feature/php-sdk/zipball/eacce4e1465e098223d46dd71029928d9a52f57e",
+                "reference": "eacce4e1465e098223d46dd71029928d9a52f57e",
                 "shasum": ""
             },
             "require": {
@@ -423,6 +423,7 @@
                 "behat/behat": "^3.11",
                 "captainhook/captainhook": "^5.10",
                 "captainhook/plugin-composer": "^5.3",
+                "dg/bypass-finals": "^1.9",
                 "ergebnis/composer-normalize": "^2.25",
                 "hamcrest/hamcrest-php": "^2.0",
                 "mdwheele/zalgo": "^0.3.1",
@@ -474,9 +475,9 @@
             ],
             "support": {
                 "issues": "https://github.com/open-feature/php-sdk/issues",
-                "source": "https://github.com/open-feature/php-sdk/tree/2.0.10"
+                "source": "https://github.com/open-feature/php-sdk/tree/2.3.0"
             },
-            "time": "2024-10-28T14:22:10+00:00"
+            "time": "2026-07-26T03:45:46+00:00"
         },
         {
             "name": "psr/http-client",

--- a/lib/OpenFeature/DevCycleProvider.php
+++ b/lib/OpenFeature/DevCycleProvider.php
@@ -6,15 +6,21 @@ use DevCycle\Api\DevCycleClient;
 use DevCycle\Model\DevCycleUser;
 
 use OpenFeature\implementation\common\Metadata;
+use OpenFeature\interfaces\common\LoggerAwareTrait;
 use OpenFeature\interfaces\common\Metadata as IMetadata;
 use OpenFeature\interfaces\flags\EvaluationContext;
 use OpenFeature\interfaces\hooks\Hook;
 use OpenFeature\interfaces\provider\Provider;
 use OpenFeature\interfaces\provider\ResolutionDetails;
-use Psr\Log\LoggerInterface;
 
 class DevCycleProvider implements Provider
 {
+    /**
+     * Provides setLogger()/getLogger(), defaulting to a PSR NullLogger when
+     * the OpenFeature API has not injected one.
+     */
+    use LoggerAwareTrait;
+
     private DevCycleClient $apiClient;
     private Metadata $metadata;
 
@@ -37,15 +43,6 @@ class DevCycleProvider implements Provider
     public function setHooks(array $hooks): void
     {
         $this->hooks = $hooks;
-    }
-
-    /**
-     * @param LoggerInterface $logger
-     * @return void
-     */
-    public function setLogger(LoggerInterface $logger): void
-    {
-        // TODO: Implement setLogger() method.
     }
 
     /**


### PR DESCRIPTION
## Summary
- Bumps `open-feature/sdk` from 2.0.10 to 2.3.0 and raises the constraint floor to `^2.3.0`
- Wires up `setLogger()` using the SDK's own `LoggerAwareTrait`, replacing the TODO stub
- 22 tests, 119 assertions, passing and identical to a pre-upgrade baseline

### Notes
`^2.0.10` already allowed 2.3.0, so the functional change is the lockfile. I raised the floor to match what we now test against, still open across 2.x. The `Provider` interface is unchanged in 2.3.0, so the upgrade itself needed no code changes.

`setLogger()` now satisfies `LoggerAwareInterface` and makes the injected logger retrievable, but no resolve path emits log lines yet. That needs the five duplicated `resolve*Value()` methods collapsed into a shared helper first.
