### PR TITLE
chore: update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/check-semantic.yml
+++ b/.github/workflows/check-semantic.yml
@@ -12,6 +12,6 @@ jobs:
     name: Semantic PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-semantic.yml
+++ b/.github/workflows/check-semantic.yml
@@ -12,6 +12,6 @@ jobs:
     name: Semantic PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.AUTOMATION_USER_TOKEN }}
           fetch-depth: 0
 
-      - uses: DevCycleHQ/release-action/prepare-release@v2.3.0
+      - uses: DevCycleHQ/release-action/prepare-release@a9e66801e2b8838e2548d8c24e1d76a109323238 # v2.4.0
         id: prepare-release
         with:
           github-token: ${{ secrets.AUTOMATION_USER_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           git push origin HEAD:main
         if: inputs.draft != true
 
-      - uses: DevCycleHQ/release-action/create-release@v2.3.0
+      - uses: DevCycleHQ/release-action/create-release@a9e66801e2b8838e2548d8c24e1d76a109323238 # v2.4.0
         id: create-release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       DEVCYCLE_SERVER_SDK_KEY: 'dvc_server_token_hash'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: php-actions/composer@v6
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3


### PR DESCRIPTION
## Summary

- Update GitHub Actions and custom action dependencies to Node 24-compatible releases.
- Update nested dependencies in composite and custom actions.
- Retain actions without an available Node 24 release.